### PR TITLE
fix: update repo links to use bluetooth-devices

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-github: ["bdraco"]
+github: ["bluetooth-devices"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,92 +6,92 @@
 
 ### Fix
 
-* Fix fetching the release tag during build ([#33](https://github.com/bdraco/fnv-hash-fast/issues/33)) ([`4dd5baa`](https://github.com/bdraco/fnv-hash-fast/commit/4dd5baaf48b8a6afb6d90dc3ce4baba89a48de34))
+* Fix fetching the release tag during build ([#33](https://github.com/bluetooth-devices/fnv-hash-fast/issues/33)) ([`4dd5baa`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/4dd5baaf48b8a6afb6d90dc3ce4baba89a48de34))
 
 ## v1.2.1 (2025-01-17)
 
 ### Fix
 
-* Update workflow to fix release process and wheel builds ([#32](https://github.com/bdraco/fnv-hash-fast/issues/32)) ([`dc796f3`](https://github.com/bdraco/fnv-hash-fast/commit/dc796f355f7e3d9b7dbb6dbf4226a22790e549e8))
+* Update workflow to fix release process and wheel builds ([#32](https://github.com/bluetooth-devices/fnv-hash-fast/issues/32)) ([`dc796f3`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/dc796f355f7e3d9b7dbb6dbf4226a22790e549e8))
 
 ## v1.2.0 (2025-01-17)
 
 ### Feature
 
-* Add aarch64 wheels via native arm runners ([#31](https://github.com/bdraco/fnv-hash-fast/issues/31)) ([`ffa9e43`](https://github.com/bdraco/fnv-hash-fast/commit/ffa9e43979374e78132f9f8867cd91fa98109050))
+* Add aarch64 wheels via native arm runners ([#31](https://github.com/bluetooth-devices/fnv-hash-fast/issues/31)) ([`ffa9e43`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/ffa9e43979374e78132f9f8867cd91fa98109050))
 
 ## v1.1.0 (2025-01-09)
 
 ### Feature
 
-* Rewrite hash function in C to improve performance ([#30](https://github.com/bdraco/fnv-hash-fast/issues/30)) ([`70eedee`](https://github.com/bdraco/fnv-hash-fast/commit/70eedee39a46c551b6247c9a85d7d6d88ad6859c))
+* Rewrite hash function in C to improve performance ([#30](https://github.com/bluetooth-devices/fnv-hash-fast/issues/30)) ([`70eedee`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/70eedee39a46c551b6247c9a85d7d6d88ad6859c))
 
 ## v1.0.2 (2024-08-23)
 
 ### Fix
 
-* Typo in release CI that prevented release from working on macos ([#22](https://github.com/bdraco/fnv-hash-fast/issues/22)) ([`d5f97e1`](https://github.com/bdraco/fnv-hash-fast/commit/d5f97e13e10a756fa5883c71466060663eb82a32))
+* Typo in release CI that prevented release from working on macos ([#22](https://github.com/bluetooth-devices/fnv-hash-fast/issues/22)) ([`d5f97e1`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/d5f97e13e10a756fa5883c71466060663eb82a32))
 
 ## v1.0.1 (2024-08-23)
 
 ### Fix
 
-* Re-release since github actions failed ([#21](https://github.com/bdraco/fnv-hash-fast/issues/21)) ([`7a5f7c2`](https://github.com/bdraco/fnv-hash-fast/commit/7a5f7c2637fe63dcba4c2f40f26be4c334ba7e7a))
+* Re-release since github actions failed ([#21](https://github.com/bluetooth-devices/fnv-hash-fast/issues/21)) ([`7a5f7c2`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/7a5f7c2637fe63dcba4c2f40f26be4c334ba7e7a))
 
 ## v1.0.0 (2024-08-22)
 
 ### Feature
 
-* Drop python 3.10 support ([#19](https://github.com/bdraco/fnv-hash-fast/issues/19)) ([`c89114d`](https://github.com/bdraco/fnv-hash-fast/commit/c89114d8b63f8d4085d14ae43387f3ffa6be829a))
+* Drop python 3.10 support ([#19](https://github.com/bluetooth-devices/fnv-hash-fast/issues/19)) ([`c89114d`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/c89114d8b63f8d4085d14ae43387f3ffa6be829a))
 
 ### Breaking
 
-* drop python 3.10 support ([#19](https://github.com/bdraco/fnv-hash-fast/issues/19)) ([`c89114d`](https://github.com/bdraco/fnv-hash-fast/commit/c89114d8b63f8d4085d14ae43387f3ffa6be829a))
+* drop python 3.10 support ([#19](https://github.com/bluetooth-devices/fnv-hash-fast/issues/19)) ([`c89114d`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/c89114d8b63f8d4085d14ae43387f3ffa6be829a))
 
 ## v0.6.1 (2024-08-22)
 
 ### Fix
 
-* Wheel builds ([#20](https://github.com/bdraco/fnv-hash-fast/issues/20)) ([`960b0dd`](https://github.com/bdraco/fnv-hash-fast/commit/960b0dd37d314e6a98bb76eb4a9a2b33fd620de6))
+* Wheel builds ([#20](https://github.com/bluetooth-devices/fnv-hash-fast/issues/20)) ([`960b0dd`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/960b0dd37d314e6a98bb76eb4a9a2b33fd620de6))
 
 ## v0.6.0 (2024-08-22)
 
 ### Feature
 
-* Python 3.13 support ([#17](https://github.com/bdraco/fnv-hash-fast/issues/17)) ([`b808ad1`](https://github.com/bdraco/fnv-hash-fast/commit/b808ad166c49f8eef13c6b477bc4c0dda57dc1d8))
+* Python 3.13 support ([#17](https://github.com/bluetooth-devices/fnv-hash-fast/issues/17)) ([`b808ad1`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/b808ad166c49f8eef13c6b477bc4c0dda57dc1d8))
 
 ### Fix
 
-* Bump pre-commit action to 3.0.1 ([#18](https://github.com/bdraco/fnv-hash-fast/issues/18)) ([`26c2026`](https://github.com/bdraco/fnv-hash-fast/commit/26c20267232ce4bceb4656d4547d89b9145c5e54))
+* Bump pre-commit action to 3.0.1 ([#18](https://github.com/bluetooth-devices/fnv-hash-fast/issues/18)) ([`26c2026`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/26c20267232ce4bceb4656d4547d89b9145c5e54))
 
 ## v0.5.0 (2023-10-18)
 
 ### Feature
 
-* Build wheel for latest cpython release ([#8](https://github.com/bdraco/fnv-hash-fast/issues/8)) ([`5bda2cb`](https://github.com/bdraco/fnv-hash-fast/commit/5bda2cbccd2bdb01ca61f885e2b1f6b3f39ca4c6))
+* Build wheel for latest cpython release ([#8](https://github.com/bluetooth-devices/fnv-hash-fast/issues/8)) ([`5bda2cb`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/5bda2cbccd2bdb01ca61f885e2b1f6b3f39ca4c6))
 
 ### Fix
 
-* Reduce size of wheels by excluding generated .cpp files ([#9](https://github.com/bdraco/fnv-hash-fast/issues/9)) ([`efc8960`](https://github.com/bdraco/fnv-hash-fast/commit/efc896027b7b7d4e6b8d41c4f4c5deb0f5128405))
+* Reduce size of wheels by excluding generated .cpp files ([#9](https://github.com/bluetooth-devices/fnv-hash-fast/issues/9)) ([`efc8960`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/efc896027b7b7d4e6b8d41c4f4c5deb0f5128405))
 
 ## v0.4.1 (2023-08-27)
 
 ### Fix
 
-* Rebuild wheels with cython 3.0.2 ([#7](https://github.com/bdraco/fnv-hash-fast/issues/7)) ([`2feb469`](https://github.com/bdraco/fnv-hash-fast/commit/2feb469e334b4541ea275fee8e60edda72c02a32))
+* Rebuild wheels with cython 3.0.2 ([#7](https://github.com/bluetooth-devices/fnv-hash-fast/issues/7)) ([`2feb469`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/2feb469e334b4541ea275fee8e60edda72c02a32))
 
 ## v0.4.0 (2023-07-24)
 
 ### Feature
 
-* Initial cpython 3.12 support ([#6](https://github.com/bdraco/fnv-hash-fast/issues/6)) ([`a1e00ad`](https://github.com/bdraco/fnv-hash-fast/commit/a1e00ad742891603edee784d499da0c20808d3b9))
+* Initial cpython 3.12 support ([#6](https://github.com/bluetooth-devices/fnv-hash-fast/issues/6)) ([`a1e00ad`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/a1e00ad742891603edee784d499da0c20808d3b9))
 
 ## v0.3.1 (2023-04-04)
 ### Fix
-* Ensure conversion is unsigned ([#5](https://github.com/bdraco/fnv-hash-fast/issues/5)) ([`7389859`](https://github.com/bdraco/fnv-hash-fast/commit/73898596872311b5a37f474fad4edf0a9a7aa5e7))
+* Ensure conversion is unsigned ([#5](https://github.com/bluetooth-devices/fnv-hash-fast/issues/5)) ([`7389859`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/73898596872311b5a37f474fad4edf0a9a7aa5e7))
 
 ## v0.3.0 (2023-04-04)
 ### Feature
-* Init version ([#3](https://github.com/bdraco/fnv-hash-fast/issues/3)) ([`fc608b7`](https://github.com/bdraco/fnv-hash-fast/commit/fc608b7a1f1fee03eab2598d25f808249ea0de95))
-* Add readme ([#2](https://github.com/bdraco/fnv-hash-fast/issues/2)) ([`c7fec4b`](https://github.com/bdraco/fnv-hash-fast/commit/c7fec4bad0586fd2c5bd79a0692d4bb56107f8d9))
-* Init repo ([#1](https://github.com/bdraco/fnv-hash-fast/issues/1)) ([`eb4612d`](https://github.com/bdraco/fnv-hash-fast/commit/eb4612d4099fdca2b1165ea405e011d375c16c63))
+* Init version ([#3](https://github.com/bluetooth-devices/fnv-hash-fast/issues/3)) ([`fc608b7`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/fc608b7a1f1fee03eab2598d25f808249ea0de95))
+* Add readme ([#2](https://github.com/bluetooth-devices/fnv-hash-fast/issues/2)) ([`c7fec4b`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/c7fec4bad0586fd2c5bd79a0692d4bb56107f8d9))
+* Init repo ([#1](https://github.com/bluetooth-devices/fnv-hash-fast/issues/1)) ([`eb4612d`](https://github.com/bluetooth-devices/fnv-hash-fast/commit/eb4612d4099fdca2b1165ea405e011d375c16c63))

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ $ pytest tests
 
 The deployment should be automated and can be triggered from the Semantic Release workflow in GitHub. The next version will be based on [the commit logs](https://python-semantic-release.readthedocs.io/en/latest/commit-log-parsing.html#commit-log-parsing). This is done by [python-semantic-release](https://python-semantic-release.readthedocs.io/en/latest/index.html) via a GitHub action.
 
-[gh-issues]: https://github.com/bdraco/fnv-hash-fast/issues
+[gh-issues]: https://github.com/bluetooth-devices/fnv-hash-fast/issues

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # FNV Hash Fast
 
 <p align="center">
-  <a href="https://github.com/bdraco/fnv-hash-fast/actions/workflows/ci.yml?query=branch%3Amain">
-    <img src="https://img.shields.io/github/actions/workflow/status/bdraco/fnv-hash-fast/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
+  <a href="https://github.com/bluetooth-devices/fnv-hash-fast/actions/workflows/ci.yml?query=branch%3Amain">
+    <img src="https://img.shields.io/github/actions/workflow/status/bluetooth-devices/fnv-hash-fast/ci.yml?branch=main&label=CI&logo=github&style=flat-square" alt="CI Status" >
   </a>
-  <a href="https://codecov.io/gh/bdraco/fnv-hash-fast">
-    <img src="https://img.shields.io/codecov/c/github/bdraco/fnv-hash-fast.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
+  <a href="https://codecov.io/gh/bluetooth-devices/fnv-hash-fast">
+    <img src="https://img.shields.io/codecov/c/github/bluetooth-devices/fnv-hash-fast.svg?logo=codecov&logoColor=fff&style=flat-square" alt="Test coverage percentage">
   </a>
 </p>
 <p align="center">
@@ -18,7 +18,7 @@
   <a href="https://github.com/pre-commit/pre-commit">
     <img src="https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white&style=flat-square" alt="pre-commit">
   </a>
-  <a href="https://codspeed.io/bdraco/fnv-hash-fast"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed Badge"/></a>
+  <a href="https://codspeed.io/bluetooth-devices/fnv-hash-fast"><img src="https://img.shields.io/endpoint?url=https://codspeed.io/badge.json" alt="CodSpeed Badge"/></a>
 </p>
 <p align="center">
   <a href="https://pypi.org/project/fnv-hash-fast/">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A fast version of fnv1a"
 authors = ["J. Nick Koston <nick@koston.org>"]
 license = "MIT"
 readme = "README.md"
-repository = "https://github.com/bdraco/fnv-hash-fast"
+repository = "https://github.com/bluetooth-devices/fnv-hash-fast"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -26,8 +26,8 @@ generate-setup-file = true
 script = "build_ext.py"
 
 [tool.poetry.urls]
-"Bug Tracker" = "https://github.com/bdraco/fnv-hash-fast/issues"
-"Changelog" = "https://github.com/bdraco/fnv-hash-fast/blob/main/CHANGELOG.md"
+"Bug Tracker" = "https://github.com/bluetooth-devices/fnv-hash-fast/issues"
+"Changelog" = "https://github.com/bluetooth-devices/fnv-hash-fast/blob/main/CHANGELOG.md"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
I have been transferring some of the projects that are under my person GitHub to OHF repos since it was hard for other contributors to help out with projects that were hosted on my personal GitHub. Bluetooth-devices has a lot of people I trust so I picked that org even though the fit is a bit strange.  We could later transfer it to home-assistant-libs if desired.