### PR TITLE
perf(build): parallelize Cython extension compilation

### DIFF
--- a/build_ext.py
+++ b/build_ext.py
@@ -22,7 +22,7 @@ fnv_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
-        if self.parallel is None:  # type: ignore[has-type]
+        if self.parallel is None:
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()

--- a/build_ext.py
+++ b/build_ext.py
@@ -22,7 +22,7 @@ fnv_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
-        if self.parallel is None:
+        if self.parallel is None:  # type: ignore[has-type, unused-ignore]
             self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()

--- a/build_ext.py
+++ b/build_ext.py
@@ -22,6 +22,8 @@ fnv_module = Extension(
 
 class BuildExt(build_ext):
     def build_extensions(self) -> None:
+        if self.parallel is None:  # type: ignore[has-type]
+            self.parallel = os.cpu_count() or 1
         try:
             super().build_extensions()
         except Exception:  # nosec


### PR DESCRIPTION
## Summary
- Default `BuildExt.parallel` to `os.cpu_count()` so per-module compilations run in parallel instead of one at a time
- Mirrors esphome/aioesphomeapi#1662, which mirrors Bluetooth-Devices/habluetooth#421 and python-zeroconf/python-zeroconf#1689

## Test plan
- [ ] CI passes