### PR TITLE
ci: use astral setup-uv to provision Python and poetry for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,22 @@ jobs:
           - "skip_extension"
           - "use_extension"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: "true"
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-          allow-prereleases: true
-      - uses: snok/install-poetry@v1.4.1
+      - name: Install poetry
+        run: uv tool install poetry
+      - name: Cache poetry virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: poetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.extension }}-${{ hashFiles('poetry.lock') }}
       - name: Install Dependencies
         run: |
           if [ "${{ matrix.extension }}" = "skip_extension" ]; then
@@ -77,11 +85,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install poetry
+        run: uv tool install poetry
       - name: Setup Python 3.13
         uses: actions/setup-python@v6
         with:
           python-version: 3.13
-      - uses: snok/install-poetry@v1.4.1
+          cache: "poetry"
       - name: Install Dependencies
         run: |
           REQUIRE_EXTENSION=1 poetry install --only=main,dev


### PR DESCRIPTION
## What

Swap the test and benchmark jobs from `actions/setup-python` plus `snok/install-poetry` over to `astral-sh/setup-uv`, which provisions both Python and poetry.

## Why

uv is faster and brings a shared download cache, so warm runs skip the Python install entirely; it also matches the pattern we already use in dbus-fast and aioesphomeapi, so the CI shape stays consistent across the sibling repos.

## How

Each test runner now sets up uv with `enable-cache: true` and the matrix's `python-version`, then installs poetry via `uv tool install poetry`; the rest of the job (poetry install, pytest, codspeed) is unchanged.

## Testing

Workflow change only, will be exercised by CI on this PR.