### PR TITLE
ci: build armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,29 +197,29 @@ jobs:
             musl: "musllinux"
           # qemu is slow, make a single
           # runner per Python version
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp311
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp312
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: "musllinux"
             pyver: cp313
           # qemu is slow, make a single
           # runner per Python version
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp311
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp312
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             qemu: armv7l
             musl: ""
             pyver: cp313


### PR DESCRIPTION
## Summary

Move the armv7l wheel builds off ubuntu-latest (x86_64 plus QEMU) and onto ubuntu-24.04-arm; QEMU is still registered to provide the 32-bit ARM binfmt handler, but running on an aarch64 host is far cheaper than aarch64 on x86_64.

Ports python-zeroconf/python-zeroconf#1741, which in turn ports aio-libs/yarl#1724.

## Test plan

- [ ] release CI builds armv7l wheels successfully on the new runner