### PR TITLE
ci: retry setup-alpine when apk.static download times out

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,6 +113,14 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Setup Alpine Linux v3.22 for x86
+        id: setup-alpine
+        continue-on-error: true
+        uses: jirutka/setup-alpine@v1
+        with:
+          arch: x86
+          branch: v3.22
+      - name: Retry Setup Alpine Linux v3.22 for x86
+        if: steps.setup-alpine.outcome == 'failure'
         uses: jirutka/setup-alpine@v1
         with:
           arch: x86


### PR DESCRIPTION
## What

Run `jirutka/setup-alpine` a second time when the first attempt fails so a transient `apk.static` download error stops killing the 32-bit Alpine check.

## Why

The action fetches `apk.static` from `gitlab.alpinelinux.org` during setup, and that endpoint has been intermittently returning `curl: (28) SSL connection timeout`; when it does, the 32-bit Alpine job fails before any of our code runs.

## How

The first invocation sets `continue-on-error: true` plus an `id`, then a second identical invocation runs only when `steps.setup-alpine.outcome == 'failure'`. The action does not retry the download itself, and `nick-fields/retry` cannot wrap a `uses:` step, so this two step pattern is the simplest mitigation.

Ports the fix from Bluetooth-Devices/ulid-transform#213.